### PR TITLE
Cache latest Laravel version

### DIFF
--- a/src/Http/Controllers/UpdateController.php
+++ b/src/Http/Controllers/UpdateController.php
@@ -2,6 +2,7 @@
 
 namespace Beyondcode\LaravelUpdateCard\Http\Controllers;
 
+use Illuminate\Support\Facades\Cache;
 use Packagist\Api\Client;
 use Beyondcode\LaravelUpdateCard\Version;
 
@@ -9,13 +10,14 @@ class UpdateController
 {
     public function check()
     {
-        $client = new Client();
 
-        $package = $client->get('laravel/laravel');
-
-        $versions = array_map(function ($version) {
-            return $version->getVersion();
-        }, $package->getVersions());
+        $versions = Cache::remember('laravel-update-card', 3600, function () {
+            $client = new Client();
+            $package = $client->get('laravel/laravel');
+            return array_map(function ($version) {
+                return $version->getVersion();
+            }, $package->getVersions());
+        });
 
         $current = app()->version();
         $latest = Version::latest($versions);


### PR DESCRIPTION
There is no need to check for Laravel version every time the dashboard is reloaded.

This PR cache latest version for one hour.